### PR TITLE
ci: upgrade to Go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Staticheck
       run: |


### PR DESCRIPTION
Upgrade CI to match the Go version specified in go.mod: https://github.com/drand/tlock/blob/main/go.mod#L3