### PR TITLE
fix: truncate file

### DIFF
--- a/cmd/tle/tle.go
+++ b/cmd/tle/tle.go
@@ -51,7 +51,7 @@ func run(log *log.Logger) error {
 
 	var dst io.Writer = os.Stdout
 	if name := flags.Output; name != "" && name != "-" {
-		f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0644)
+		f, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
 		if err != nil {
 			return fmt.Errorf("failed to open output file %q: %v", name, err)
 		}


### PR DESCRIPTION
## Description

Closes https://github.com/drand/tlock/issues/28
Truncate file per https://stackoverflow.com/questions/62000607/how-to-overwrite-file-content-in-golang

## Testing
### Before
```
$ tle --armor -D 10d -o output.txt bar.txt
$ cat output.txt
-----BEGIN AGE ENCRYPTED FILE-----
YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHRsb2NrIDMyNTg0ODggNzY3Mjc5N2Y1
NDhmM2Y0NzQ4YWM0YmYzMzUyZmM2YzZiNjQ2OGM5YWQ0MGFkNDU2YTM5NzU0NWM2
ZTJkZjViZgppNXFFZm5lb2dUaWRQZHJMMUowV2tRSnNQQUlUeGFTd2EvMzFvU04r
YjBpRit2Y0VnazhUbVpOUHdYWTVraW82CnJuZTVEd3hHaHZBUzdyZEtDaTM0YXln
aUFzanhlaDhqemRwU3FWeDFXSVkKLS0tIFpkcGF2MVl4M25WRlRQMC9ZTlV0QmpV
bXZWVmd0amZxRWNjOXBXSDZwWEUKSQucgbb1VEWlCFZU59TVCyz4rkePi27BZtBl
MnxUE/MQMhFo
-----END AGE ENCRYPTED FILE-----
C4LxlifCAUXI0fBDs4
c9smj7Ovm1btIae7cPZ7SxLUWMEZ/ZQ0PrupqP9SLXv0
-----END AGE ENCRYPTED FILE-----
```
### After
```
$ ./tle --armor -D 10d -o output.txt bar.txt
$ cat output.txt
-----BEGIN AGE ENCRYPTED FILE-----
YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHRsb2NrIDMyNTg2NjYgNzY3Mjc5N2Y1
NDhmM2Y0NzQ4YWM0YmYzMzUyZmM2YzZiNjQ2OGM5YWQ0MGFkNDU2YTM5NzU0NWM2
ZTJkZjViZgpvVmNDbVBaR3BaVnlQeEV2aDl6OUFueThnSWkwRGhPZHpmcHc1TVJN
dDk0NmdSLzFKU2twblNnWlhqVUs2YkxoCmt1NkcvRE9tbk5QYWNsUUFTekUvWFY5
QUFCUW5KOE1oeUlHdmk5blVIdWsKLS0tIGFtZmZWZk1JV1I2ZFN5MFlRdDFYTHhJ
STR5RDFwczd5UDFuRUNtR2QwVkkK0vewmqQjEDn8HYq6/x2i6nlETlJwNlbOfrV1
3qdS+lyBzUbF
-----END AGE ENCRYPTED FILE-----
```