### PR TITLE
CLI now correctly parses duration

### DIFF
--- a/cmd/tle/commands/commands_test.go
+++ b/cmd/tle/commands/commands_test.go
@@ -34,31 +34,31 @@ func Test_ParseDuration(t *testing.T) {
 			name:     "months are parsed correctly",
 			duration: "1M",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
-			expected: time.Duration(31*24) * time.Hour,
+			expected: 31 * 24 * time.Hour,
 		},
 		{
 			name:     "years are parsed correctly",
 			duration: "1y",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
-			expected: time.Duration(365*24) * time.Hour,
+			expected: 365 * 24 * time.Hour,
 		},
 		{
 			name:     "a mix of timespans parse successfuly",
 			duration: "1y1M1s",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
-			expected: time.Duration(365*24)*time.Hour + time.Duration(31*24)*time.Hour + time.Duration(1)*time.Second,
+			expected: 365*24*time.Hour + 31*24*time.Hour + 1*time.Second,
 		},
 		{
 			name:     "a mix of timespans in a funny order parse successfully",
 			duration: "2s1y1M",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
-			expected: time.Duration(365*24)*time.Hour + time.Duration(31*24)*time.Hour + time.Duration(2)*time.Second,
+			expected: 365*24*time.Hour + 31*24*time.Hour + 2*time.Second,
 		},
 		{
 			name:     "times with multiple digits parse successfully",
 			duration: "203m",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
-			expected: time.Duration(203) * time.Minute,
+			expected: 203 * time.Minute,
 		},
 		{
 			name:     "parsing an invalid timespan character fails",
@@ -76,13 +76,25 @@ func Test_ParseDuration(t *testing.T) {
 			name:     "0 values are in the middle are allowed",
 			duration: "1y0M1m",
 			date:     time.Now(),
-			expected: time.Duration(365*24)*time.Hour + time.Duration(1)*time.Minute,
+			expected: 365*24*time.Hour + 1*time.Minute,
 		},
 		{
 			name:     "total of 0 should also be fine",
 			duration: "0s",
 			date:     time.Now(),
 			expected: 0 * time.Second,
+		},
+		{
+			name:     "where characters are repeated, the last one wins",
+			duration: "3s2s1s",
+			date:     time.Now(),
+			expected: 1 * time.Second,
+		},
+		{
+			name:     "where characters are repeated, the last one wins even if there are others in the way",
+			duration: "3s2s1d1s",
+			date:     time.Now(),
+			expected: 24*time.Hour + 1*time.Second,
 		},
 	}
 

--- a/cmd/tle/commands/commands_test.go
+++ b/cmd/tle/commands/commands_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 	"time"
 )
@@ -51,6 +54,13 @@ func Test_ParseDuration(t *testing.T) {
 			err:      nil,
 		},
 		{
+			name:     "multiDigitParsesCorrectly",
+			duration: "203m",
+			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
+			expected: time.Duration(203) * time.Minute,
+			err:      nil,
+		},
+		{
 			name:     "parseInvalid",
 			duration: "1C",
 			date:     time.Now(),
@@ -84,4 +94,31 @@ func Test_ParseDuration(t *testing.T) {
 
 		})
 	}
+}
+
+func TestEncryptionWithDurationOverflow(t *testing.T) {
+	flags := Flags{
+		Encrypt:  true,
+		Decrypt:  false,
+		Network:  defaultNetwork,
+		Chain:    defaultChain,
+		Round:    0,
+		Duration: "292277042628y",
+		Armor:    false,
+	}
+	err := Encrypt(flags, os.Stdout, bytes.NewBufferString("very nice"), nil)
+	require.ErrorIs(t, err, ErrDurationOverflow)
+}
+
+func TestEncryptionWithDurationOverflowUsingOtherUnits(t *testing.T) {
+	flags := Flags{
+		Encrypt:  true,
+		Decrypt:  false,
+		Network:  defaultNetwork,
+		Chain:    defaultChain,
+		Duration: "292277042627y12m1d",
+		Armor:    false,
+	}
+	err := Encrypt(flags, os.Stdout, bytes.NewBufferString("very nice"), nil)
+	require.ErrorIs(t, err, ErrDurationOverflow)
 }

--- a/cmd/tle/commands/commands_test.go
+++ b/cmd/tle/commands/commands_test.go
@@ -85,16 +85,10 @@ func Test_ParseDuration(t *testing.T) {
 			expected: 0 * time.Second,
 		},
 		{
-			name:     "where characters are repeated, the last one wins",
-			duration: "3s2s1s",
-			date:     time.Now(),
-			expected: 1 * time.Second,
-		},
-		{
-			name:     "where characters are repeated, the last one wins even if there are others in the way",
+			name:     "if characters are repeated, an error is returned",
 			duration: "3s2s1d1s",
 			date:     time.Now(),
-			expected: 24*time.Hour + 1*time.Second,
+			err:      ErrDuplicateDuration,
 		},
 	}
 

--- a/cmd/tle/commands/commands_test.go
+++ b/cmd/tle/commands/commands_test.go
@@ -19,58 +19,70 @@ func Test_ParseDuration(t *testing.T) {
 
 	tests := []test{
 		{
-			name:     "parseDay",
+			name:     "seconds are parsed correctly",
+			duration: "1s",
+			date:     time.Now(),
+			expected: 1 * time.Second,
+		},
+		{
+			name:     "days are parsed correctly",
 			duration: "1d",
 			date:     time.Now(),
 			expected: 24 * time.Hour,
-			err:      nil,
 		},
 		{
-			name:     "parseMonth",
+			name:     "months are parsed correctly",
 			duration: "1M",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
 			expected: time.Duration(31*24) * time.Hour,
-			err:      nil,
 		},
 		{
-			name:     "parseYear",
+			name:     "years are parsed correctly",
 			duration: "1y",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
 			expected: time.Duration(365*24) * time.Hour,
-			err:      nil,
 		},
 		{
-			name:     "parseMixed",
+			name:     "a mix of timespans parse successfuly",
 			duration: "1y1M1s",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
 			expected: time.Duration(365*24)*time.Hour + time.Duration(31*24)*time.Hour + time.Duration(1)*time.Second,
-			err:      nil,
 		},
 		{
-			name:     "parseMixedInAFunnyOrder",
+			name:     "a mix of timespans in a funny order parse successfully",
 			duration: "2s1y1M",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
 			expected: time.Duration(365*24)*time.Hour + time.Duration(31*24)*time.Hour + time.Duration(2)*time.Second,
-			err:      nil,
 		},
 		{
-			name:     "multiDigitParsesCorrectly",
+			name:     "times with multiple digits parse successfully",
 			duration: "203m",
 			date:     time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC),
 			expected: time.Duration(203) * time.Minute,
-			err:      nil,
 		},
 		{
-			name:     "parseInvalid",
+			name:     "parsing an invalid timespan character fails",
 			duration: "1C",
 			date:     time.Now(),
-			err:      ErrInvalidDuration,
+			err:      ErrInvalidDurationType,
 		},
 		{
-			name:     "parseMissingMultiplier",
+			name:     "missing multipliers fails",
 			duration: "DM",
 			date:     time.Now(),
 			err:      ErrInvalidDurationMultiplier,
+		},
+		{
+			name:     "0 values are in the middle are allowed",
+			duration: "1y0M1m",
+			date:     time.Now(),
+			expected: time.Duration(365*24)*time.Hour + time.Duration(1)*time.Minute,
+		},
+		{
+			name:     "total of 0 should also be fine",
+			duration: "0s",
+			date:     time.Now(),
+			expected: 0 * time.Second,
 		},
 	}
 
@@ -82,7 +94,7 @@ func Test_ParseDuration(t *testing.T) {
 			}
 
 			if tc.err != nil && tc.err != err {
-				t.Fatalf("expecting parsing error '%s'; got %v", ErrInvalidDuration, err)
+				t.Fatalf("expecting parsing error '%s'; got %v", ErrInvalidDurationType, err)
 			}
 
 			expected := tc.date.Add(tc.expected)
@@ -107,7 +119,7 @@ func TestEncryptionWithDurationOverflow(t *testing.T) {
 		Armor:    false,
 	}
 	err := Encrypt(flags, os.Stdout, bytes.NewBufferString("very nice"), nil)
-	require.ErrorIs(t, err, ErrDurationOverflow)
+	require.ErrorIs(t, err, ErrInvalidDurationValue)
 }
 
 func TestEncryptionWithDurationOverflowUsingOtherUnits(t *testing.T) {
@@ -120,5 +132,5 @@ func TestEncryptionWithDurationOverflowUsingOtherUnits(t *testing.T) {
 		Armor:    false,
 	}
 	err := Encrypt(flags, os.Stdout, bytes.NewBufferString("very nice"), nil)
-	require.ErrorIs(t, err, ErrDurationOverflow)
+	require.ErrorIs(t, err, ErrInvalidDurationValue)
 }

--- a/cmd/tle/commands/encrypt.go
+++ b/cmd/tle/commands/encrypt.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	"filippo.io/age/armor"
@@ -13,7 +13,8 @@ import (
 	"github.com/drand/tlock/networks/http"
 )
 
-var ErrInvalidDuration = errors.New("invalid duration unit")
+var ErrInvalidDuration = errors.New("unsupported duration type - note: drand can only support as long as seconds")
+var ErrInvalidDurationMultiplier = errors.New("errors must contain a multiplier, e.g. 1d not just d")
 
 // Encrypt performs the encryption operation. This requires the implementation
 // of an encoder for reading/writing to disk, a network for making calls to the
@@ -41,61 +42,130 @@ func Encrypt(flags Flags, dst io.Writer, src io.Reader, network *http.Network) e
 		return tlock.Encrypt(dst, src, flags.Round)
 
 	case flags.Duration != "":
-		duration, err := parseDuration(time.Now(), flags.Duration)
+		durations, err := parseDurations(flags.Duration)
 		if err != nil {
 			return err
 		}
-
-		roundNumber := network.RoundNumber(time.Now().Add(duration))
+		decryptionTime := durations.from(time.Now())
+		roundNumber := network.RoundNumber(decryptionTime)
 		return tlock.Encrypt(dst, src, roundNumber)
 	}
 
 	return nil
 }
 
-// parseDuration parses the duration and can handle days, months, and years.
-func parseDuration(t time.Time, duration string) (time.Duration, error) {
-	d, err := time.ParseDuration(duration)
-	if err == nil {
-		return d, nil
+type combinedDuration struct {
+	seconds int
+	minutes int
+	hours   int
+	weeks   int
+	days    int
+	months  int
+	years   int
+}
+
+func (c *combinedDuration) apply(value int, multiplier DurationMultiplier) {
+	switch multiplier {
+	case Second:
+		c.seconds = c.seconds + value
+	case Minute:
+		c.minutes = c.minutes + value
+	case Hour:
+		c.hours = c.hours + value
+	case Day:
+		c.days = c.days + value
+	case Week:
+		c.weeks = c.weeks + value
+	case Month:
+		c.months = c.months + value
+	case Year:
+		c.years = c.years + value
 	}
+}
 
-	// M has to be capitalised to avoid conflict with minutes.
-	if !strings.ContainsAny(duration, "dMy") {
-		return time.Second, ErrInvalidDuration
-	}
+func (c *combinedDuration) from(someTime time.Time) time.Time {
+	return someTime.AddDate(
+		c.years, c.months, c.days+(c.weeks*7),
+	).Add(
+		time.Duration(int64(c.minutes)) * time.Minute,
+	).Add(
+		time.Duration(int64(c.seconds)) * time.Second,
+	)
+}
 
-	now := time.Now()
-
-	pieces := strings.Split(duration, "d")
-	if len(pieces) == 2 {
-		days, err := strconv.Atoi(pieces[0])
-		if err != nil {
-			return time.Second, fmt.Errorf("parse day duration: %w", err)
+func parseDurations(input string) (combinedDuration, error) {
+	out := combinedDuration{}
+	i := input
+	for {
+		if i == "" {
+			return out, nil
 		}
-		diff := now.AddDate(0, 0, days).Sub(now)
-		return diff, nil
-	}
 
-	pieces = strings.Split(duration, "M")
-	if len(pieces) == 2 {
-		months, err := strconv.Atoi(pieces[0])
-		if err != nil {
-			return time.Second, fmt.Errorf("parse month duration: %w", err)
+		ints, remainingInput, err := parsePrecedingInt(i)
+		if ints == 0 || err != nil {
+			return combinedDuration{}, ErrInvalidDurationMultiplier
 		}
-		diff := now.AddDate(0, months, 0).Sub(now)
-		return diff, nil
-	}
 
-	pieces = strings.Split(duration, "y")
-	if len(pieces) == 2 {
-		years, err := strconv.Atoi(pieces[0])
+		duration, err := parseNextDuration(remainingInput)
 		if err != nil {
-			return time.Second, fmt.Errorf("parse year duration: %w", err)
+			return combinedDuration{}, err
 		}
-		diff := now.AddDate(years, 0, 0).Sub(now)
-		return diff, nil
+
+		i = remainingInput[1:]
+		out.apply(ints, duration)
+	}
+}
+
+func parsePrecedingInt(input string) (int, string, error) {
+	preceding := 0
+	for i := 0; i < len(input); i++ {
+		if input[i] < '0' || input[i] > '9' {
+			return preceding, input[i:], nil
+		}
+
+		mantissa, err := strconv.Atoi(string(input[i]))
+		if err != nil {
+			return 0, input, err
+		}
+		exponent := int(math.Pow(float64(10), float64(i)))
+		preceding = preceding + mantissa*exponent
+	}
+	return preceding, "", nil
+}
+
+type DurationMultiplier = int8
+
+const (
+	Second DurationMultiplier = iota
+	Minute
+	Hour
+	Day
+	Week
+	Month
+	Year
+)
+
+func parseNextDuration(input string) (DurationMultiplier, error) {
+	if input == "" {
+		return 0, ErrInvalidDuration
 	}
 
-	return time.Second, fmt.Errorf("parse duration: %w", err)
+	switch input[0] {
+	case 'y':
+		return Year, nil
+	case 'M':
+		return Month, nil
+	case 'w':
+		return Week, nil
+	case 'd':
+		return Day, nil
+	case 'h':
+		return Hour, nil
+	case 'm':
+		return Minute, nil
+	case 's':
+		return Second, nil
+	default:
+		return 0, ErrInvalidDuration
+	}
 }

--- a/cmd/tle/commands/encrypt.go
+++ b/cmd/tle/commands/encrypt.go
@@ -91,9 +91,9 @@ func (c *combinedDuration) from(someTime time.Time) time.Time {
 	return someTime.AddDate(
 		c.years, c.months, c.days+(c.weeks*7),
 	).Add(
-		time.Duration(int64(c.minutes)) * time.Minute,
+		c.minutes * time.Minute,
 	).Add(
-		time.Duration(int64(c.seconds)) * time.Second,
+		c.seconds * time.Second,
 	)
 }
 

--- a/cmd/tle/commands/encrypt.go
+++ b/cmd/tle/commands/encrypt.go
@@ -68,23 +68,47 @@ type combinedDuration struct {
 	years   int
 }
 
-func (c *combinedDuration) apply(value int, multiplier DurationMultiplier) {
+var ErrDuplicateDuration = errors.New("you cannot use the same duration unit specifier twice in one duration")
+
+func (c *combinedDuration) apply(value int, multiplier DurationMultiplier) error {
 	switch multiplier {
 	case Second:
+		if c.seconds != 0 {
+			return ErrDuplicateDuration
+		}
 		c.seconds = value
 	case Minute:
+		if c.minutes != 0 {
+			return ErrDuplicateDuration
+		}
 		c.minutes = value
 	case Hour:
+		if c.hours != 0 {
+			return ErrDuplicateDuration
+		}
 		c.hours = value
 	case Day:
+		if c.days != 0 {
+			return ErrDuplicateDuration
+		}
 		c.days = value
 	case Week:
+		if c.weeks != 0 {
+			return ErrDuplicateDuration
+		}
 		c.weeks = value
 	case Month:
+		if c.months != 0 {
+			return ErrDuplicateDuration
+		}
 		c.months = value
 	case Year:
+		if c.years != 0 {
+			return ErrDuplicateDuration
+		}
 		c.years = value
 	}
+	return nil
 }
 
 func (c *combinedDuration) from(someTime time.Time) time.Time {
@@ -116,7 +140,10 @@ func parseDurations(input string) (combinedDuration, error) {
 		}
 
 		i = remainingInput[1:]
-		out.apply(ints, duration)
+		err = out.apply(ints, duration)
+		if err != nil {
+			return combinedDuration{}, err
+		}
 	}
 }
 

--- a/cmd/tle/commands/encrypt.go
+++ b/cmd/tle/commands/encrypt.go
@@ -71,19 +71,19 @@ type combinedDuration struct {
 func (c *combinedDuration) apply(value int, multiplier DurationMultiplier) {
 	switch multiplier {
 	case Second:
-		c.seconds = c.seconds + value
+		c.seconds = value
 	case Minute:
-		c.minutes = c.minutes + value
+		c.minutes = value
 	case Hour:
-		c.hours = c.hours + value
+		c.hours = value
 	case Day:
-		c.days = c.days + value
+		c.days = value
 	case Week:
-		c.weeks = c.weeks + value
+		c.weeks = value
 	case Month:
-		c.months = c.months + value
+		c.months = value
 	case Year:
-		c.years = c.years + value
+		c.years = value
 	}
 }
 

--- a/cmd/tle/commands/encrypt.go
+++ b/cmd/tle/commands/encrypt.go
@@ -14,7 +14,7 @@ import (
 
 var ErrInvalidDuration = errors.New("unsupported duration type - note: drand can only support as long as seconds")
 var ErrDurationOverflow = errors.New("the duration you entered is too large and would cause an overflow")
-var ErrInvalidDurationMultiplier = errors.New("errors must contain a multiplier, e.g. 1d not just d")
+var ErrInvalidDurationMultiplier = errors.New("must contain a multiplier, e.g. 1d not just d")
 
 // Encrypt performs the encryption operation. This requires the implementation
 // of an encoder for reading/writing to disk, a network for making calls to the

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,13 @@ require (
 	github.com/drand/drand v1.4.3-testnet
 	github.com/drand/kyber v1.1.13
 	github.com/drand/kyber-bls12381 v0.2.2
+	github.com/stretchr/testify v1.7.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -199,7 +199,9 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -591,6 +593,7 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- fixed a bug where duration strings after the first entry would be ignored, e.g. 1d15m would encrypt for only 1d and ignore the 15m
- fixed a bug where integer overflow could occur when adding a date too far in the future