### PR TITLE
Fix: Make tests deterministic 

### DIFF
--- a/tlock_age_test.go
+++ b/tlock_age_test.go
@@ -15,6 +15,9 @@ const (
 )
 
 func Test_WrapUnwrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network-dependent tests in short mode")
+	}
 	network, err := http.NewNetwork(testnetHost, testnetChainHash)
 	if err != nil {
 		t.Fatalf("network error %s", err)


### PR DESCRIPTION
This PR resolves issue #34 by making tests deterministic and removing network dependencies for the short test suite.

## Changes

### Skip network-dependent tests in short mode
Added `testing.Short()` checks to skip network-dependent tests when running `go test -short`:
- `TestEarlyDecryptionWithDuration`
- `TestEarlyDecryptionWithRound`
- `TestDecryptVariousChainhashes`
- `TestDecryptStrict`
- `TestInteropWithJS`
- `Test_WrapUnwrap`

### Add deterministic test vectors
Added two new deterministic test functions that use fixed network data without requiring network access:
- `TestDeterministicEncryptionDecryption` - Tests encryption/decryption using the tlock API
- `TestDeterministicTimeLock` - Tests TimeLock/TimeUnlock functions directly

### Interop tests
The existing `TestInteropWithJS` already provides interop testing with tlock-js library using known test vectors.

## Testing

- `go test -short ./...` - All tests pass, network tests skipped
- `go test ./...` - All tests pass, including network tests

## Benefits

- Faster test runs in CI/CD (use `go test -short`)
- Deterministic test vectors for reliable testing
- No network dependency for most tests
- Easy to run tests without internet connectivity

Closes #34 