### PR TITLE
Fix http network construction: avoid log.Fatal and validate host

### DIFF
--- a/networks/http/http.go
+++ b/networks/http/http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -41,14 +40,26 @@ type Network struct {
 	genesis   int64
 }
 
-// NewNetwork constructs a network for use that will use the http client.
-func NewNetwork(host string, chainHash string) (*Network, error) {
+func normalizeHost(host string) (string, error) {
 	if !strings.HasPrefix(host, "http") {
 		host = "https://" + host
 	}
-	_, err := url.Parse(host + "/" + chainHash)
+	u, err := url.Parse(host)
 	if err != nil {
-		log.Fatal(err)
+		return "", fmt.Errorf("parsing host url: %w", err)
+	}
+	// Ensure this is a proper absolute URL and not just a path.
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("parsing host url: missing scheme or host in %q", host)
+	}
+	return host, nil
+}
+
+// NewNetwork constructs a network for use that will use the http client.
+func NewNetwork(host string, chainHash string) (*Network, error) {
+	host, err := normalizeHost(host)
+	if err != nil {
+		return nil, err
 	}
 
 	hash, err := hex.DecodeString(chainHash)
@@ -70,7 +81,7 @@ func NewNetwork(host string, chainHash string) (*Network, error) {
 	}
 
 	if info.HashString() != chainHash {
-		return nil, fmt.Errorf("chain hash mistmatch: (requested) %s!=%s (received)", chainHash, info.HashString())
+		return nil, fmt.Errorf("chain hash mismatch: (requested) %s!=%s (received)", chainHash, info.HashString())
 	}
 
 	sch, err := crypto.SchemeFromName(info.Scheme)

--- a/networks/http/http_test.go
+++ b/networks/http/http_test.go
@@ -56,3 +56,34 @@ func TestNetwork_ChainHash(t *testing.T) {
 		})
 	}
 }
+
+func TestNewNetwork_InvalidInputsReturnError(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		chainHash string
+	}{
+		{
+			name:     "invalid host url (parse error)",
+			host:     "http://%",
+			chainHash: "52db9ba70e0cc0f6eaf7803dd07447a1f5477735fd3f661792ba94600c84e971",
+		},
+		{
+			name:     "invalid host url (missing host)",
+			host:     "https://",
+			chainHash: "52db9ba70e0cc0f6eaf7803dd07447a1f5477735fd3f661792ba94600c84e971",
+		},
+		{
+			name:     "invalid chain hash hex",
+			host:     "api.drand.sh",
+			chainHash: "not-hex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewNetwork(tt.host, tt.chainHash)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Stop `tlock/networks/http.NewNetwork` from terminating the process on bad input.
- Add strict host validation so invalid URLs are rejected early and deterministically.
- Fix a typo in the “chain hash mismatch” error message.
- Add unit tests for invalid inputs (invalid host URL, missing host, invalid chain hash hex).

## Problem

`tlock/networks/http.NewNetwork` is part of a library API, but it previously called `log.Fatal` when URL parsing failed, which would exit the entire process of any downstream application importing `tlock` (including CLIs, services, or libraries) and is unexpected and makes error handling and testing difficult.

Additionally, the previous URL parsing check was too permissive: some malformed host inputs could still parse as a URL path and slip through, causing failures later in the network setup instead of being rejected up front.

Initially I expected url.Parse to reject these inputs, but some malformed hosts still parsed as paths, which is why the stricter validation lives in normalizeHost.

## Changes

**File:** `networks/http/http.go`

- Replace the `log.Fatal` call in `NewNetwork` with a returned error so callers
  can handle invalid input without the process exiting.
- Introduce `normalizeHost(host)` to:
  - Add a default `https://` scheme when the host doesn’t include one.
  - Parse and validate that the URL is absolute (has both scheme and host).
- Fix typo in error message:
  - `chain hash mistmatch` → `chain hash mismatch`

**File:** `networks/http/http_test.go`

- Add `TestNewNetwork_InvalidInputsReturnError` with deterministic cases:
  - Invalid host URL parse error (e.g. `http://%`)
  - Missing host (e.g. `https://`)
  - Invalid chain hash hex (e.g. `not-hex`)

## Notes

This change improves robustness for any downstream code using `tlock` as a library: invalid host strings now return errors instead of terminating the entire process.

## Testing

From the `tlock` module:

```bash
cd tlock
go test ./...
```

This runs:

- `github.com/drand/tlock`
- `github.com/drand/tlock/networks/fixed`
- `github.com/drand/tlock/networks/http`
- `github.com/drand/tlock/cmd/tle/commands`

and passes with the new tests in place.